### PR TITLE
Update protocol version

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70810;
+static const int PROTOCOL_VERSION = 70815;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -21,7 +21,7 @@ static const int GETHEADERS_VERSION = 70077;
 
 //! disconnect from peers older than this proto version
 static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70710;
-static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70810;
+static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70815;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
Right now you have unintended forks due to some poor planned changes.  By changing the protocol version it is going to be a lot easier to keep other's from getting put on a unintended fork.  You'll also want to update the send-seeder code with this new protocol version.
Once you get over 50% on this new protocol version you can use the spork key to force a switch ending the fork nightmare.